### PR TITLE
Uses a custom "format" function instead over "format-util"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/open-draft/outvariant"
-  },
-  "dependencies": {
-    "@types/format-util": "^1.0.1",
-    "format-util": "^1.0.5"
   }
 }

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -1,0 +1,63 @@
+import { format } from './format'
+
+it('does not format a string without positionals', () => {
+  expect(format('hello world')).toEqual('hello world')
+  expect(format('%s hello %d %o world %j')).toEqual('%s hello %d %o world %j')
+})
+
+it('formats a single string (%s) positional', () => {
+  expect(format('hello %s', 'world')).toEqual('hello world')
+})
+
+it('formats multiple string (%s) positionals', () => {
+  expect(format('%s, my name is %s', 'Amy', 'Jake')).toEqual(
+    'Amy, my name is Jake'
+  )
+  expect(format('%s:%s', '12', '34')).toEqual('12:34')
+})
+
+it('formats escaped string (%s)', () => {
+  expect(format('%%s', 'hello')).toEqual('%s hello')
+})
+
+it('formats digit (%d) positionals', () => {
+  expect(format('%d', 32)).toEqual('32')
+  expect(format('I am %d years old', 18)).toEqual('I am 18 years old')
+})
+
+it('replaces invalid digits with NaN when formatting %d', () => {
+  expect(format('%d', 'word')).toEqual('NaN')
+  expect(format('I am %d years old', 'seven')).toEqual('I am NaN years old')
+})
+
+it('formats a JSON string (%j)', () => {
+  expect(format('%j', 'hello')).toEqual(`"hello"`)
+})
+
+it('formats a JSON Array (%j)', () => {
+  expect(format('%j', [1, 2, 3])).toEqual('[1,2,3]')
+})
+
+it('formats object (%o) positionals', () => {
+  expect(format('%o', { id: 1, name: 'Kate' })).toEqual(
+    `{"id":1,"name":"Kate"}`
+  )
+})
+
+it('formats a string given as %o', () => {
+  expect(format('%o', 'hello')).toEqual('hello')
+})
+
+it('formats an Error given as %o', () => {
+  expect(format('%o', new Error('Custom error message'))).toEqual(
+    'Error: Custom error message'
+  )
+})
+
+it('formats an Array given as %o', () => {
+  expect(format('%o', [1, 2, 3])).toEqual('[1,2,3]')
+})
+
+it('appends unresolved positionals to the string', () => {
+  expect(format('hello %s', 'world', 'Jake', 32)).toEqual('hello world Jake 32')
+})

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,66 @@
+const POSITIONALS_EXP = /(%?)(%([sdjo]))/g
+
+function serializePositional(positional: any, flag: string): any {
+  switch (flag) {
+    // Strings.
+    case 's':
+      return positional
+
+    // Digits.
+    case 'd':
+    case 'i':
+      return Number(positional)
+
+    // JSON.
+    case 'j':
+      return JSON.stringify(positional)
+
+    // Objects.
+    case 'o': {
+      // Preserve stings to prevent extra quotes around them.
+      if (typeof positional === 'string') {
+        return positional
+      }
+
+      const json = JSON.stringify(positional)
+
+      // If the positional isn't serializable, return it as-is.
+      if (json === '{}' || json === '[]' || /^\[object .+?\]$/.test(json)) {
+        return positional
+      }
+
+      return json
+    }
+  }
+}
+
+export function format(message: string, ...positionals: any[]): string {
+  if (positionals.length === 0) {
+    return message
+  }
+
+  let positionalIndex = 0
+  let formattedMessage = message.replace(
+    POSITIONALS_EXP,
+    (match, isEscaped, _, flag) => {
+      const positional = positionals[positionalIndex]
+      const value = serializePositional(positional, flag)
+
+      if (!isEscaped) {
+        positionalIndex++
+        return value
+      }
+
+      return match
+    }
+  )
+
+  // Append unresolved positionals to string as-is.
+  if (positionalIndex < positionals.length) {
+    formattedMessage += ` ${positionals.slice(positionalIndex).join(' ')}`
+  }
+
+  formattedMessage = formattedMessage.replace(/%{2,2}/g, '%')
+
+  return formattedMessage
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './invariant'
+export * from './format'

--- a/src/invariant.test.ts
+++ b/src/invariant.test.ts
@@ -38,5 +38,5 @@ it('supports positional values in the error message', () => {
   // Objects.
   expect(() =>
     invariant(false, 'Cannot create user: %o', { name: 'John' })
-  ).toThrow(new InvariantError(`Cannot create user: { name: 'John' }`))
+  ).toThrow(new InvariantError(`Cannot create user: {"name":"John"}`))
 })

--- a/src/invariant.ts
+++ b/src/invariant.ts
@@ -1,4 +1,4 @@
-import format from 'format-util'
+import { format } from './format'
 
 const STACK_FRAMES_TO_IGNORE = 2
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -570,11 +570,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/format-util@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/format-util/-/format-util-1.0.1.tgz#6fd9a41194776e2f33e2846ae955da8dbc8af4d1"
-  integrity sha512-uqU+S8ZeHlEslQgMzD6fpYhZlCqMfWR8MqoIMHy4uEy6VIkFqtZC25GKhl9n7fGmL0BZ51xrB5Ak8Wkb9oKw3A==
-
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -1197,11 +1192,6 @@ form-data@^3.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
-
-format-util@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
-  integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The [format-util](https://github.com/tmpfs/format-util) package is a great replacement for the standard `util` from Node.js. However, there are a few limitations that made me decide to remove it as a dependency:

1. It does `require('util')` in the entry module. I suspect that's done for the sake of using the standard `util` package when available, but this also means that the browser support is delegated to the bundler. This complicates the bundling process for the sake of a pure utility function that doesn't have to rely on `util` to exist.
2. It [mutates](https://github.com/tmpfs/format-util/blob/0c989942c959b179eec294a4e725afd63e743f18/format.js#L6) the given `args` positionals. I understand that string mutation is not as serious as Object mutation, but I'd still prefer to rely on code that does not mutate functions' inputs—that's never a good thing to do. 

I'm replacing the said dependency with a custom implementation of `format` (previously `interpolate`), but adding some unit tests to ensure that the custom function covers all the scenarios that `format-util` covers. 

> Interestingly enough, `format-util` is not a polyfill for `util` (for some reason I've thought of it as such, although that's rightfully never mentioned in the README). For instance, it handles object (`%o`) differently than `util`, and doesn't support `%i` and `%c` that Node.js supports. 

## Changes compared to `interpolate`

Compared to the previously used `interpolate` function, the new `format` has a number of changes that improve its operability and align the expectations with such towards the Node's `util`:

1. Unresolved positionals are appended to the string, instead of being ignored.
2. Numbers are converted to `Number`, which produces `NaN` given an invalid number as the `%d` value.
3. Respects escaped positionals (i.e. `%%s`). 